### PR TITLE
Made ONEP host more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Editor swapfiles
+.*.sw?
+*~

--- a/provision.go
+++ b/provision.go
@@ -140,15 +140,13 @@ type ProvRestModel interface {
 func ProvCall(vendorToken, method, path string) (interface{}, error) {
     client := &http.Client{}
 
-    var serverUrl = ""
-
     // https://m2.exosite.com/provision/manage/model/flow_sensor/POC_FLOW_01
+    var serverUrl = ""
+    serverUrl = "https://" + ONEPHost + "/provision/"
     if InDev {
-            serverUrl = "https://m2-dev.exosite.com/provision/"
-        } else {
-            serverUrl = "https://m2.exosite.com/provision/"
-        }
-    
+        serverUrl = "https://m2-dev.exosite.com/provision/"
+    }
+
     req, _ := http.NewRequest(method, serverUrl + path, nil)            
     req.Header.Add("X-Exosite-Token", vendorToken)
 

--- a/rpc.go
+++ b/rpc.go
@@ -5,7 +5,6 @@ package goonep
 import (
     "bytes"
     "encoding/json"
-    //    "fmt"
     "io/ioutil"
     "net/http"
     //"log"
@@ -15,6 +14,8 @@ var version = "0.1"
 var DomainKey = ""
 
 var InDev = false
+// Set this to, e.g., "m2.exosite.com" or "localhost:18393"
+var ONEPHost = "m2.exosite.com"
 
 type Response struct {
     Results []Result
@@ -62,12 +63,10 @@ func CallMulti(auth interface{}, calls []interface{}) (Response, error) {
     }
 
     var serverUrl = ""
-
+    serverUrl = "https://" + ONEPHost + "/api:v1/rpc/process"
     if InDev {
-            serverUrl = "https://m2-dev.exosite.com/api:v1/rpc/process"
-        } else {
-            serverUrl = "https://m2.exosite.com/api:v1/rpc/process"
-        }
+        serverUrl = "https://m2-dev.exosite.com/api:v1/rpc/process"
+    }
 
     buf, _ := json.Marshal(requestBody)
     requestBodyBuf := bytes.NewBuffer(buf)


### PR DESCRIPTION
I tried to leave the `InDev` functionality working in case anything uses it, but I want to be able to set my 1P host to any arbitrary thing, so I added the `OnepHost` variable.
